### PR TITLE
BUGFIX: Make sure the regular TranslationTab.js and LangSelector.js files aren't included by reusing the combined JS.

### DIFF
--- a/code/TranslatableModelAdmin.php
+++ b/code/TranslatableModelAdmin.php
@@ -13,6 +13,7 @@ abstract class TranslatableModelAdmin extends ModelAdmin {
 	public $Locale = null;
 	
 	function init() {
+		Requirements::set_combined_files_enabled(false); // Is there a better way?
 		parent::init();
 		Requirements::customScript("SiteTreeHandlers.controller_url = '" . $this->Link() . "';");
 		Requirements::block(CMS_DIR . '/javascript/TranslationTab.js');


### PR DESCRIPTION
There very well could be a better way to do this, however this ultimately seemed simplest and most efficient. I also assume this module will be completely re-built once 3.0 is released.
